### PR TITLE
Fix incorrect switch cases in getWorkspaceConfig()

### DIFF
--- a/src/Scripts/helpers.js
+++ b/src/Scripts/helpers.js
@@ -51,9 +51,9 @@ function observeConfigWithWorkspaceOverride(name, fn) {
 function getWorkspaceConfig(name) {
 	const value = nova.workspace.config.get(name)
 	switch (value) {
-		case 'Enable':
+		case 'Enabled':
 			return true
-		case 'Disable':
+		case 'Disabled':
 			return false
 		case 'Global Setting':
 			return null


### PR DESCRIPTION
Changed case values from `Enable` and `Disable` to the correct `Enabled` and `Disabled`.
