### PR TITLE
Add test file scrambler and formatting test cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "rollup -c",
-    "extract-strings": "node src/scripts/extract-strings.js"
+    "extract-strings": "node src/scripts/extract-strings.js",
+    "prepare:testfiles": "node scripts/scramble-testfiles.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/scramble-testfiles.js
+++ b/scripts/scramble-testfiles.js
@@ -345,9 +345,11 @@ function simulateLessMistakes(content) {
 }
 
 function simulateVueMistakes(content) {
-  const templateMatch = content.match(/<template>([\s\S]*?)<\/template>/)
-  const scriptMatch = content.match(/<script[\s\S]*?<\/script>/)
-  const styleMatch = content.match(/<style[\s\S]*?<\/style>/)
+  const templateMatch = content.match(
+    /<template\b[^>]*>([\s\S]*?)<\/template\s*>/i,
+  )
+  const scriptMatch = content.match(/<script\b[^>]*>([\s\S]*?)<\/script[^>]*>/i)
+  const styleMatch = content.match(/<style\b[^>]*>([\s\S]*?)<\/style\s*>/i)
 
   let scrambledTemplate = ''
   let scrambledScript = ''
@@ -361,11 +363,11 @@ function simulateVueMistakes(content) {
         const trimmed = line.trim()
 
         return line
-          .replace(/:\s+(\w+)/g, ':$1') // tighten :placeholder
-          .replace(/@\s+(\w+)/g, '@$1') // tighten @click
-          .replace(/"\s+(:|@)/g, '" $1') // preserve spacing between attributes
-          .replace(/\s{2,}/g, ' ') // collapse extra spaces
-          .replace(/^\s+/g, '') // remove indent
+          .replace(/:\s+(\w+)/g, ':$1')
+          .replace(/@\s+(\w+)/g, '@$1')
+          .replace(/"\s+(:|@)/g, '" $1')
+          .replace(/\s{2,}/g, ' ')
+          .replace(/^\s+/g, '')
       })
       .join('\n')
   }

--- a/scripts/scramble-testfiles.js
+++ b/scripts/scramble-testfiles.js
@@ -1,0 +1,533 @@
+const fs = require('fs')
+const path = require('path')
+
+const TESTS_DIR = path.join(__dirname, '..', 'tests')
+
+const mistakeInjectors = {
+  '.css': simulateCssMistakes,
+  '.js': simulateJsMistakes,
+  '.jsx': simulateJsMistakes,
+  '.ts': simulateTsMistakes,
+  '.php': simulatePhpMistakes,
+  '.md': simulateMarkdownMistakes,
+  '.html': simulateHtmlMistakes,
+  '.graphql': simulateGraphqlMistakes,
+  '.json': simulateJsonMistakes,
+  '.scss': simulateScssMistakes,
+  '.less': simulateLessMistakes,
+  '.vue': simulateVueMistakes,
+  '.xml': simulateXmlMistakes,
+  '.yaml': simulateYamlMistakes,
+  '.sql': simulateSqlMistakes,
+  '.conf': simulateNginxMistakes,
+}
+
+fs.readdirSync(TESTS_DIR).forEach((file) => {
+  const fullPath = path.join(TESTS_DIR, file)
+  const ext = path.extname(file)
+  const formatter = mistakeInjectors[ext]
+
+  if (!fs.statSync(fullPath).isFile()) return
+  if (!formatter) {
+    console.warn(`Skipping unsupported file: ${file}`)
+    return
+  }
+
+  const original = fs.readFileSync(fullPath, 'utf-8')
+  const scrambled = formatter(original)
+  fs.writeFileSync(fullPath, scrambled, 'utf-8')
+  console.log(`Scrambled: ${file}`)
+})
+
+// === FORMATTER FUNCTIONS ===
+
+function simulateCssMistakes(content) {
+  const lines = content.split('\n')
+  let inBlockComment = false
+
+  return lines
+    .map((line) => {
+      const trimmed = line.trim()
+
+      // Start or end of a block comment
+      if (trimmed.startsWith('/*')) inBlockComment = true
+      if (inBlockComment) {
+        if (trimmed.endsWith('*/')) inBlockComment = false
+        return line // Preserve as-is
+      }
+
+      // Preserve line comments or blank lines
+      if (trimmed.startsWith('//') || trimmed === '') return line
+
+      // Apply formatting mistakes
+      return line
+        .replace(/^\s+/g, '') // remove leading indent
+        .replace(/\s*{\s*/g, '{ ')
+        .replace(/\s*}\s*/g, '} ')
+        .replace(/\s*:\s*/g, ':')
+        .replace(/\s*;\s*/g, ';')
+        .replace(/,\s*/g, ', ')
+        .replace(/\s+/g, ' ')
+    })
+    .join('\n')
+}
+
+function simulateJsMistakes(content) {
+  const lines = content.split('\n')
+  const result = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const currentLine = lines[i]
+    const trimmed = currentLine.trim()
+
+    const nextLine = lines[i + 1]?.trim()
+    const isComment =
+      trimmed.startsWith('//') ||
+      trimmed.startsWith('/*') ||
+      trimmed.startsWith('*') ||
+      trimmed.startsWith('*/')
+
+    // Preserve comments and their original blank-line spacing
+    result.push(currentLine)
+
+    const nextLineWasBlank = lines[i + 1] === ''
+    if (isComment && nextLineWasBlank) {
+      result.push('') // preserve intended blank line
+      i++ // skip next (blank) line
+    }
+
+    // Format actual code lines (non-blank, non-comment)
+    if (trimmed && !isComment) {
+      const scrambled = currentLine.replace(/\s{2,}/g, ' ').replace(/^\s+/g, '')
+      result[result.length - 1] = scrambled
+    }
+  }
+
+  return result.join('\n')
+}
+
+function simulateTsMistakes(content) {
+  return simulateJsMistakes(content)
+}
+
+function simulatePhpMistakes(content) {
+  const lines = content.split('\n')
+  const result = []
+
+  let inHtml = false
+
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i]
+    const trimmed = line.trim()
+
+    // Detect switch to HTML
+    if (trimmed === '?>') inHtml = true
+    if (trimmed.startsWith('<?php')) inHtml = false
+
+    // Leave HTML untouched
+    if (inHtml || trimmed.startsWith('<!')) {
+      result.push(line)
+      continue
+    }
+
+    // Skip scrambling for lines with echo/return + quotes
+    const isSensitiveLine =
+      /\b(echo|return)\b/.test(trimmed) && /["'].*["']/.test(trimmed)
+
+    if (
+      trimmed === '' ||
+      trimmed.startsWith('<?') ||
+      trimmed.startsWith('//') ||
+      trimmed.startsWith('/*') ||
+      trimmed.startsWith('*') ||
+      trimmed.startsWith('*/') ||
+      trimmed.startsWith('namespace') ||
+      trimmed.startsWith('use ') ||
+      isSensitiveLine
+    ) {
+      result.push(line)
+      continue
+    }
+
+    // Safe formatting-only scramble
+    const scrambled = line
+      .replace(/ {2,}/g, ' ')
+      .replace(/\s*([=;:{}(),\[\]])\s*/g, '$1')
+      .replace(/^\s{4}/, '  ') // reduce indent
+      .replace(/\s+$/g, '')
+
+    result.push(scrambled)
+  }
+
+  return result.join('\n')
+}
+
+function simulateMarkdownMistakes(content) {
+  const lines = content.split('\n')
+  let inFencedBlock = false
+
+  return lines
+    .map((line) => {
+      const trimmed = line.trim()
+
+      // Toggle code block mode
+      if (trimmed.startsWith('```')) {
+        inFencedBlock = !inFencedBlock
+        return line
+      }
+
+      const shouldSkip =
+        trimmed === '' ||
+        /^\s*(#|>)/.test(line) || // headings, blockquotes
+        /`[^`]+`/.test(line) || // inline code
+        (/^\s*\/\//.test(line) && inFencedBlock) // comment inside code block
+
+      if (shouldSkip) return line
+
+      // Line contains a template literal — don't touch
+      if (/`[^`]*\$\{[^}]+\}[^`]*`/.test(line)) return line
+
+      // List item — scramble only the content
+      const listMatch = line.match(/^(\s*([-+*]|\d+\.)\s+)(.*)$/)
+      if (listMatch) {
+        const [, prefix, , text] = listMatch
+        return prefix + scramble(text)
+      }
+
+      // Otherwise, scramble entire line
+      return scramble(line)
+    })
+    .join('\n')
+
+  function scramble(text) {
+    return text
+      .split(/(\s+)/)
+      .map((chunk, i) => {
+        if (i % 2 === 1) {
+          return chunk + ' '.repeat(Math.floor(Math.random() * 3)) // add 0–2 spaces
+        }
+        return chunk
+      })
+      .join('')
+  }
+}
+
+function simulateHtmlMistakes(content) {
+  const lines = content.split('\n')
+  const result = []
+  let inScript = false
+
+  for (let line of lines) {
+    const trimmed = line.trim()
+
+    // Start/end script detection
+    if (trimmed.startsWith('<script')) inScript = true
+    if (trimmed.startsWith('</script>')) inScript = false
+
+    // Keep comments and blank lines exactly
+    if (trimmed.startsWith('<!--') || trimmed === '') {
+      result.push(line)
+      continue
+    }
+
+    // Leave script content messy but line-by-line
+    if (
+      inScript &&
+      !trimmed.startsWith('<script') &&
+      !trimmed.startsWith('</script>')
+    ) {
+      result.push(
+        line
+          .replace(/ {2,}/g, ' ')
+          .replace(/;\s*/g, '; ')
+          .replace(/\s+/g, ' ')
+          .trim(),
+      )
+      continue
+    }
+
+    // Avoid collapsing inline tags (e.g. <input> <br> <hr> <img>)
+    result.push(
+      line
+        .replace(/ {2,}/g, ' ')
+        .replace(/^\s+/g, '') // remove leading indent
+        .replace(/\s+\/>/g, ' />'), // normalize self-closing spacing
+    )
+  }
+
+  return result.join('\n')
+}
+
+function simulateGraphqlMistakes(content) {
+  return content
+    .split('\n')
+    .map((line) => {
+      const trimmed = line.trim()
+      if (trimmed.startsWith('#') || trimmed === '') return line
+      return line.replace(/\s+/g, ' ')
+    })
+    .join('\n')
+}
+
+function simulateJsonMistakes(content) {
+  return content
+    .replace(/:\s*/g, ': ') // fix colon spacing
+    .replace(/,\s*/g, ', ') // comma spacing
+    .replace(/ {2,}/g, ' ') // excess spaces
+    .replace(/\n{3,}/g, '\n\n') // too many line breaks
+}
+
+function simulateScssMistakes(content) {
+  const lines = content.split('\n')
+  const result = []
+
+  for (let line of lines) {
+    const trimmed = line.trim()
+
+    // Leave comments alone
+    if (
+      trimmed === '' ||
+      trimmed.startsWith('//') ||
+      trimmed.startsWith('/*') ||
+      trimmed.startsWith('*') ||
+      trimmed.startsWith('*/')
+    ) {
+      result.push(line)
+      continue
+    }
+
+    let scrambled = line
+      .replace(/^\s+/g, '') // remove leading indent
+      .replace(/\s{2,}/g, ' ') // collapse multiple spaces
+      .replace(/\s*([:{}();,{}])\s*/g, '$1') // tighten syntax characters
+      .replace(/#\{\s*(.*?)\s*\}/g, '#{$1}') // tighten interpolations
+      .replace(/and\(/g, 'and (') // fix missing space after "and"
+      .replace(/:\s*(\d+)/g, ': $1') // fix colon spacing for numbers
+      .replace(/,\s*/g, ', ') // normalize comma spacing
+
+    result.push(scrambled)
+  }
+
+  return result.join('\n')
+}
+
+function simulateLessMistakes(content) {
+  const lines = content.split('\n')
+  const result = []
+
+  for (let line of lines) {
+    const trimmed = line.trim()
+
+    if (
+      trimmed === '' ||
+      trimmed.startsWith('//') ||
+      trimmed.startsWith('/*') ||
+      trimmed.startsWith('*') ||
+      trimmed.startsWith('*/')
+    ) {
+      result.push(line)
+      continue
+    }
+
+    let scrambled = line
+      .replace(/^\s+/g, '') // remove leading indent
+      .replace(/\s{2,}/g, ' ') // collapse multiple spaces
+      .replace(/\s*([{}();])\s*/g, '$1') // tighten around syntax
+      .replace(/:\s*/g, ': ') // normalize to one space after colon
+      .replace(/,\s*/g, ', ') // comma spacing
+      .replace(/#\{\s*(.*?)\s*\}/g, '#{$1}') // tighten interpolation
+      .replace(/&:\s+([a-zA-Z])/g, '&:$1') // fix & pseudo selectors
+
+    result.push(scrambled)
+  }
+
+  return result.join('\n')
+}
+
+function simulateVueMistakes(content) {
+  const templateMatch = content.match(/<template>([\s\S]*?)<\/template>/)
+  const scriptMatch = content.match(/<script[\s\S]*?<\/script>/)
+  const styleMatch = content.match(/<style[\s\S]*?<\/style>/)
+
+  let scrambledTemplate = ''
+  let scrambledScript = ''
+  let scrambledStyle = ''
+
+  // --- TEMPLATE SCRAMBLE ---
+  if (templateMatch) {
+    scrambledTemplate = templateMatch[1]
+      .split('\n')
+      .map((line) => {
+        const trimmed = line.trim()
+
+        return line
+          .replace(/:\s+(\w+)/g, ':$1') // tighten :placeholder
+          .replace(/@\s+(\w+)/g, '@$1') // tighten @click
+          .replace(/"\s+(:|@)/g, '" $1') // preserve spacing between attributes
+          .replace(/\s{2,}/g, ' ') // collapse extra spaces
+          .replace(/^\s+/g, '') // remove indent
+      })
+      .join('\n')
+  }
+
+  // --- SCRIPT SCRAMBLE ---
+  if (scriptMatch) {
+    scrambledScript = scriptMatch[0]
+      .split('\n')
+      .map((line) => {
+        const trimmed = line.trim()
+        if (trimmed === '' || trimmed.startsWith('//')) return line
+        return line
+          .replace(/\s{2,}/g, ' ')
+          .replace(/^\s+/g, '')
+          .replace(/,\s*/g, ', ')
+          .replace(/:\s*/g, ': ')
+          .replace(/;\s*/g, '; ')
+          .replace(/{\s*/g, '{ ')
+          .replace(/\s*}/g, ' }')
+      })
+      .join('\n')
+  }
+
+  // --- STYLE SCRAMBLE ---
+  if (styleMatch) {
+    scrambledStyle = simulateScssMistakes(styleMatch[0])
+  }
+
+  return [
+    '<template>',
+    scrambledTemplate.trim(),
+    '</template>',
+    '',
+    scrambledScript.trim(),
+    '',
+    scrambledStyle.trim(),
+  ].join('\n\n')
+}
+
+function simulateXmlMistakes(content) {
+  const lines = content.split('\n')
+  const result = []
+
+  let inCdata = false
+  let inTextBlock = false
+
+  for (let line of lines) {
+    const trimmed = line.trim()
+
+    if (trimmed.includes('<![CDATA[')) {
+      inCdata = true
+      result.push(line)
+      continue
+    }
+
+    if (trimmed.includes(']]>')) {
+      inCdata = false
+      result.push(line) // preserve leading indentation
+      continue
+    }
+
+    // Detect text-only lines
+    if (!inCdata && !trimmed.startsWith('<') && !trimmed.endsWith('>')) {
+      inTextBlock = true
+    } else {
+      inTextBlock = false
+    }
+
+    // Preserve raw content
+    if (
+      inCdata ||
+      inTextBlock ||
+      trimmed.startsWith('<?xml') ||
+      trimmed.startsWith('<!--') ||
+      trimmed.startsWith('-->') ||
+      trimmed === ''
+    ) {
+      result.push(line)
+      continue
+    }
+
+    // Scramble only tag lines
+    const scrambled = line
+      .replace(/ {2,}/g, ' ')
+      .replace(/\s*=\s*/g, '=')
+      .replace(/\s+\/>/g, ' />')
+      .replace(/^\s+/, '')
+      .replace(/\s+$/, '')
+
+    result.push(scrambled)
+  }
+
+  return result.join('\n')
+}
+
+function simulateYamlMistakes(content) {
+  return content
+    .split('\n')
+    .map((line) => {
+      const trimmed = line.trim()
+
+      // Preserve blank lines, comments, block indicators, and YAML document markers
+      if (
+        trimmed === '' ||
+        trimmed.startsWith('#') ||
+        trimmed.endsWith('|') ||
+        trimmed.endsWith('>') ||
+        trimmed.startsWith('<<: *') ||
+        trimmed.startsWith('---') ||
+        trimmed.startsWith('...')
+      ) {
+        return line
+      }
+
+      // Preserve lines starting with a quoted key entirely.
+      if (/^['"].+['"]\s*:/.test(trimmed)) {
+        return line
+      }
+
+      // Minimal change: normalize colon spacing on unquoted keys.
+      // This replaces any spaces (or lack thereof) before and after a colon with exactly one space after.
+      return line.replace(/\s*:\s*/g, ': ')
+    })
+    .join('\n')
+}
+
+function simulateSqlMistakes(content) {
+  return content
+    .replace(/ {2,}/g, ' ')
+    .replace(/\t+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/^\s+/gm, '') // unindent
+}
+
+function simulateNginxMistakes(content) {
+  return content
+    .split('\n')
+    .map((line) => {
+      const trimmed = line.trim()
+
+      // Preserve blank lines and comments as-is.
+      if (trimmed === '' || trimmed.startsWith('#')) {
+        return line
+      }
+
+      // Minimal changes for non-comment lines:
+      let scrambled = line
+
+      // Remove leading indentation.
+      scrambled = scrambled.replace(/^\s+/, '')
+
+      // Collapse multiple spaces into one.
+      scrambled = scrambled.replace(/\s{2,}/g, ' ')
+
+      // Remove extra spaces before semicolons.
+      scrambled = scrambled.replace(/\s*;/g, ';')
+
+      // Normalize spacing around braces.
+      scrambled = scrambled.replace(/\s*{\s*/g, ' { ')
+      scrambled = scrambled.replace(/\s*}\s*/g, ' } ')
+
+      return scrambled
+    })
+    .join('\n')
+}

--- a/tests/css.test.css
+++ b/tests/css.test.css
@@ -1,0 +1,74 @@
+/* Single-line comment */
+body,
+html {
+  margin: 0;
+  padding: 0;
+  background: #fff;
+  color: red;
+}
+
+/* Multi-line
+   comment */
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem 2rem 3rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+h1,
+h2,
+h3 {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  font-weight: bold;
+}
+
+a:link,
+a:visited {
+  text-decoration: none;
+  color: blue;
+}
+
+a:hover,
+a:focus {
+  color: #0056b3;
+  text-decoration: underline;
+}
+
+ul,
+ol {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+input[type='text'],
+input[type='password'] {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ddd;
+  transition: border-color 0.3s;
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem;
+  }
+  body {
+    font-size: 14px;
+  }
+}
+
+/* Keyframes test */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/tests/flow.test.js
+++ b/tests/flow.test.js
@@ -1,0 +1,61 @@
+// @flow
+
+/* Variable annotations */
+let count: number = 42
+const name: string = 'Alice'
+var active: boolean = true
+
+/* Function annotations */
+function greet(name: string, age: ?number): string {
+  return `Hello ${name}, you are ${age ?? 'unknown'} years old.`
+}
+
+/* Arrow function with inline types */
+const square = (n: number): number => {
+  return n * n
+}
+
+/* Union and intersection types */
+type UserID = string | number
+type Admin = { role: 'admin' }
+type Person = { name: string } & Admin
+
+function getUser(id: UserID): Person {
+  return {
+    name: 'Bob',
+    role: 'admin',
+  }
+}
+
+/* Nullable types and optional properties */
+type Profile = {
+  id: number,
+  nickname?: string,
+  email: ?string,
+}
+
+/* Generic types */
+function identity<T>(value: T): T {
+  return value
+}
+
+type Response<T> = {
+  data: T,
+  error: ?string,
+}
+
+const res: Response<Array<number>> = {
+  data: [1, 2, 3],
+  error: null,
+}
+
+/* Casts */
+const el = (document.getElementById('app'): any)
+
+/* Mixed types */
+function handle(input: mixed): string {
+  if (typeof input === 'string') {
+    return input.toUpperCase()
+  }
+  return 'not a string'
+}

--- a/tests/graphql.test.graphql
+++ b/tests/graphql.test.graphql
@@ -1,0 +1,62 @@
+# Basic query with arguments and aliases
+query getUserInfo($id: ID!, $verbose: Boolean = false) {
+  user: userById(id: $id) {
+    id
+    name
+    email
+    profilePicture(size: 100)
+    address {
+      street
+      city
+      zip
+    }
+    friends(first: 10) {
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+    ...UserDetails
+  }
+}
+
+# Fragment with nested fields
+fragment UserDetails on User {
+  bio
+  joinedDate
+  posts(limit: 5) {
+    title
+    published
+    tags
+  }
+}
+
+# Mutation example
+mutation updateUser($input: UpdateUserInput!) {
+  updateUser(input: $input) {
+    user {
+      id
+      name
+      email
+    }
+    success
+    error {
+      message
+      code
+    }
+  }
+}
+
+# Subscription example
+subscription onNewMessage {
+  messageSent {
+    id
+    content
+    sender {
+      id
+      username
+    }
+  }
+}

--- a/tests/html.test.html
+++ b/tests/html.test.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="style.css" disabled />
+  </head>
+  <body>
+    <!-- This is a comment -->
+    <div id="main" class="container" data-active>
+      <h1>Heading</h1>
+      <p>This is a paragraph with irregular spacing.</p>
+      <img src="image.jpg" alt="An image" />
+      <br />
+      <hr />
+
+      <div>
+        <section>
+          <article><p>Nested content</p></article>
+        </section>
+      </div>
+
+      <form action="/submit" method="post">
+        <input type="text" name="username" />
+        <input type="checkbox" checked />
+        <button type="submit">Submit</button>
+      </form>
+
+      <script>
+        const foo = { bar: 'baz' }
+        console.log(foo)
+      </script>
+    </div>
+  </body>
+</html>

--- a/tests/javascript.test.js
+++ b/tests/javascript.test.js
@@ -1,0 +1,73 @@
+// Variable declarations with inconsistent spacing
+let a = 1,
+  b = 2
+const obj = { foo: 'bar', baz: 42 }
+
+// Functions with messy formatting
+function add(x, y) {
+  return x + y
+}
+const subtract = (x, y) => {
+  return x - y
+}
+
+// Async/await and Promises
+async function fetchData(url) {
+  try {
+    const res = await fetch(url)
+    return await res.json()
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+// Arrays, objects, nesting, trailing commas
+const list = [1, 2, 3, 4]
+const user = {
+  id: 1,
+  name: 'Alice',
+  tags: ['admin', 'editor', 'user'],
+  settings: { darkMode: true, notifications: false },
+}
+
+// Template literals and ternaries
+const msg = `Hello, ${user.name} - you are ${user.tags.includes('admin') ? 'an admin' : 'a user'}`
+
+// Arrow functions and higher-order functions
+;[1, 2, 3].map((n) => {
+  return n * 2
+})
+
+// Optional chaining, nullish coalescing
+const city = user?.address?.city ?? 'Unknown'
+
+// Class with static, getters, and methods
+class Person {
+  static species = 'Homo sapiens'
+  constructor(name) {
+    this.name = name
+  }
+  get upperName() {
+    return this.name.toUpperCase()
+  }
+  greet() {
+    console.log(`Hi, I'm ${this.name}`)
+  }
+}
+
+// Immediately-invoked function
+;(function () {
+  console.log('IIFE')
+})()
+
+// Mixed single/double quotes and backticks
+const single = 'single'
+const double = 'double'
+const backtick = `backtick`
+
+// Misaligned indentation
+if (a > 0) {
+  console.log('positive')
+} else {
+  console.log('non-positive')
+}

--- a/tests/json.test.json
+++ b/tests/json.test.json
@@ -1,0 +1,39 @@
+{
+  "name": "PrettierTest",
+  "version": "1.0.0",
+  "description": "A test file with bad formatting",
+  "scripts": {
+    "start": "node index.js",
+    "test": "jest --coverage"
+  },
+  "dependencies": {
+    "react": "^17.0.2",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "eslint": "^7.32.0",
+    "prettier": "^2.8.8"
+  },
+  "keywords": ["formatter", "prettier", "test"],
+  "author": "Jane Doe",
+  "license": "MIT",
+  "config": {
+    "settingA": true,
+    "settingB": false,
+    "nested": {
+      "level1": {
+        "level2": {
+          "level3": {
+            "value": [1, 2, 3, { "deep": true }]
+          }
+        }
+      }
+    }
+  },
+  "nullValue": null,
+  "numberList": [5, 10, 15, 20, 25],
+  "bools": {
+    "on": true,
+    "off": false
+  }
+}

--- a/tests/jsx.test.jsx
+++ b/tests/jsx.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+
+const Button = ({ label, onClick, disabled = false }) => {
+  return (
+    <button onClick={onClick} disabled={disabled}>
+      {' '}
+      {label}{' '}
+    </button>
+  )
+}
+
+function App() {
+  const handleClick = () => {
+    console.log('Clicked!')
+  }
+
+  return (
+    <div className="App">
+      <h1> Hello, world! </h1>
+      <Button label="Click me" onClick={handleClick} />
+      <input type="text" placeholder="Enter something" />
+      <CustomComponent
+        propOne="value1"
+        propTwo={123}
+        propThree={() => {
+          return true
+        }}
+      />
+      {[1, 2, 3].map((n, index) => (
+        <span key={index}> {n} </span>
+      ))}
+    </div>
+  )
+}
+
+const CustomComponent = (props) => {
+  return (
+    <section>
+      <p>{props.propOne}</p>
+      <p>{props.propTwo}</p>
+      <p>{props.propThree && props.propThree()}</p>
+    </section>
+  )
+}
+
+export default App

--- a/tests/less.test.less
+++ b/tests/less.test.less
@@ -1,0 +1,51 @@
+// Variables
+@primary-color: #4a90e2;
+@padding: 10px 15px;
+@font-stack: 'Helvetica Neue', Arial, sans-serif;
+
+// Mixins
+.rounded(@radius: 4px) {
+  border-radius: @radius;
+  -webkit-border-radius: @radius;
+}
+
+// Nesting and selectors
+.container {
+  padding: @padding;
+  background: @primary-color;
+  font-family: @font-stack;
+
+  .header,
+  .footer {
+    color: white;
+    .rounded(6px);
+  }
+
+  &:hover {
+    background: darken(@primary-color, 10%);
+  }
+
+  @media (max-width: 768px) {
+    padding: 5px;
+    .header {
+      font-size: 12px;
+    }
+  }
+}
+
+// Operations
+.column {
+  width: (100% / 3);
+  margin-left: (20px / 2);
+}
+
+// Escaping
+.icon-@{name} {
+  background-image: url('/icons/@{name}.png');
+}
+
+// Functions
+.banner {
+  background-color: lighten(@primary-color, 20%);
+  border: 1px solid fade(@primary-color, 50%);
+}

--- a/tests/markdown.test.md
+++ b/tests/markdown.test.md
@@ -1,0 +1,60 @@
+# Markdown Test File
+
+This file is intended to test the formatting capabilities of the Nova Prettier Extension for Markdown. It contains various Markdown syntax elements, including headings, paragraphs, lists, blockquotes, inline code, fenced code blocks, tables, links, images, and more.
+
+## Headings
+
+# Heading 1
+
+## Heading 2
+
+### Heading 3
+
+## Paragraphs
+
+This is a paragraph with some sample text. It is designed to test how the formatter handles long lines, extra spaces, and line wrapping.
+
+Another paragraph follows, with **bold text**, _italic text_, and **_bold italic text_**.
+
+## Lists
+
+### Unordered List (hyphens)
+
+- Item one
+- Item two
+  - Nested item
+  - Another nested item
+    - Deep nested item
+
+### Unordered List (asterisks)
+
+- Item A
+- Item B
+  - Nested A
+  - Nested B
+
+### Ordered List
+
+1. First item
+2. Second item
+   1. Sub-item 1
+   2. Sub-item 2
+
+## Blockquotes
+
+> This is a blockquote that spans multiple lines.
+> It should be indented properly and maintain its structure.
+
+## Inline Code
+
+Use `npm install` to install dependencies.
+
+## Fenced Code Block
+
+```javascript
+// Example JavaScript code block
+function greet(name) {
+  return `Hello, ${name}!`
+}
+console.log(greet('Nova'))
+```

--- a/tests/nginx.test.conf
+++ b/tests/nginx.test.conf
@@ -1,0 +1,73 @@
+# Global directives
+user             nginx;
+worker_processes auto;
+error_log        /var/log/nginx/error.log warn;
+pid              /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+    log_format          main
+      '$remote_addr - $remote_user [$time_local] "$request" '
+      '$status $body_bytes_sent "$http_referer" '
+      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log          /var/log/nginx/access.log main;
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+    server_tokens       off;
+    gzip                on;
+    gzip_types          text/plain application/json application/javascript
+      text/css;
+
+    # Server block
+    server {
+        listen      80 default_server;
+        listen      [::]:80 default_server;
+        server_name _;
+        root        /usr/share/nginx/html;
+        index       index.html index.htm;
+
+        location / {
+            try_files $uri $uri/ =404;
+        }
+
+        location ~ \.php$ {
+            include      snippets/fastcgi-php.conf;
+            fastcgi_pass unix:/run/php/php7.4-fpm.sock;
+        }
+
+        location ~ /\.ht {
+            deny all;
+        }
+
+        error_page  404 /custom_404.html;
+
+        location = /custom_404.html {
+            root /usr/share/nginx/html/errors;
+        }
+    }
+
+    # SSL server block example
+    server {
+        listen              443 ssl;
+        server_name         example.com;
+        ssl_certificate     /etc/ssl/certs/example.crt;
+        ssl_certificate_key /etc/ssl/private/example.key;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+
+        location / {
+            proxy_pass       http://localhost:3000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+}

--- a/tests/php.test.php
+++ b/tests/php.test.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+// Variable declarations with inconsistent spacing
+$foo = 'bar';
+$baz = ['one', 'two', 'three'];
+
+// Functions with messy formatting
+function greet($name = 'World')
+{
+    return "Hello, $name!";
+}
+
+// Class with properties, methods, visibility
+class User
+{
+    public $name;
+    private $email;
+
+    public function __construct($name, $email)
+    {
+        $this->name = $name;
+        $this->email = $email;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getEmail()
+    {
+        return $this->email;
+    }
+}
+
+// Conditionals and loops
+for ($i = 0; $i < 10; $i++) {
+    if ($i % 2 === 0) {
+        echo "$i is even\n";
+    } else {
+        echo "$i is odd\n";
+    }
+}
+
+// Arrays: short vs long syntax, spacing, trailing commas
+$data = [
+    'name' => 'Alice',
+    'age' => 30,
+    'languages' => ['PHP', 'JavaScript'],
+];
+
+// Inline HTML
+?>
+<!DOCTYPE html>
+<html>
+<head><title>Test</title></head>
+<body>
+  <h1><?php echo $foo; ?></h1>
+</body>
+</html>
+<?php
+// Anonymous functions and closures
+$log = function ($message) use ($foo) {
+    echo "[LOG] $message - $foo\n";
+};
+
+// Namespaces and use statements
+namespace App\Controllers;
+use App\Models\User as UserModel;
+
+// Match expressions
+$value = match ($foo) {
+    'bar' => 1,
+    'baz' => 2,
+    default => 0,
+};
+

--- a/tests/scss.test.scss
+++ b/tests/scss.test.scss
@@ -1,0 +1,77 @@
+// Variables
+$primary-color: #3498db;
+$padding: 10px 20px;
+$font-stack: 'Helvetica Neue', Arial, sans-serif;
+
+// Mixins
+@mixin button-style($bg, $fg: #fff) {
+  background-color: $bg;
+  color: $fg;
+  padding: $padding;
+  border: none;
+  border-radius: 4px;
+  &:hover {
+    background-color: darken($bg, 10%);
+  }
+}
+
+// Functions
+@function spacing($factor) {
+  @return $factor * 8px;
+}
+
+// Nested selectors and media queries
+.container {
+  font-family: $font-stack;
+  padding: spacing(2);
+
+  h1,
+  h2 {
+    color: $primary-color;
+    margin-bottom: spacing(1);
+  }
+
+  .button {
+    @include button-style($primary-color);
+    font-weight: bold;
+    margin-top: 16px;
+
+    &.disabled {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+  }
+
+  @media screen and (max-width: 768px) {
+    padding: spacing(1);
+
+    .button {
+      width: 100%;
+    }
+  }
+}
+
+// Placeholder selectors and inheritance
+%card {
+  border: 1px solid #ccc;
+  padding: spacing(2);
+  background: #fff;
+}
+
+.card {
+  @extend %card;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+// List + map usage
+$colors: (
+  primary: #3498db,
+  danger: #e74c3c,
+  success: #2ecc71,
+);
+
+@each $name, $color in $colors {
+  .text-#{$name} {
+    color: $color;
+  }
+}

--- a/tests/sql.test.sql
+++ b/tests/sql.test.sql
@@ -1,0 +1,81 @@
+-- Table creation with basic constraints
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  username VARCHAR(50) NOT NULL UNIQUE,
+  email VARCHAR(100) NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Insert multiple rows with spacing issues
+INSERT INTO
+  users (username, email)
+VALUES
+  ('alice', 'alice@example.com'),
+  ('bob', 'bob@example.com');
+
+-- Select with JOIN, WHERE, GROUP BY, ORDER BY
+SELECT
+  u.id,
+  u.username,
+  COUNT(p.id) AS post_count
+FROM
+  users u
+  LEFT JOIN posts p ON p.user_id = u.id
+WHERE
+  u.created_at > '2023-01-01'
+GROUP BY
+  u.id,
+  u.username
+ORDER BY
+  post_count DESC;
+
+-- Update using subquery
+UPDATE users
+SET
+  email = u.username || '@newdomain.com'
+FROM
+  (
+    SELECT
+      id,
+      username
+    FROM
+      users
+  ) AS u
+WHERE
+  users.id = u.id;
+
+-- Delete rows based on a date condition
+DELETE FROM sessions
+WHERE
+  last_activity < DATE('now', '-30 day');
+
+-- Nested SELECT using inline subqueries
+SELECT
+  u.username,
+  (
+    SELECT
+      COUNT(*)
+    FROM
+      posts p
+    WHERE
+      p.user_id = u.id
+  ) AS total_posts
+FROM
+  users u
+WHERE
+  u.email IS NOT NULL;
+
+-- Simple function-style logic as a reusable SELECT
+SELECT
+  CASE
+    WHEN EXISTS (
+      SELECT
+        1
+      FROM
+        sessions
+      WHERE
+        user_id = 1
+        AND active = 1
+    ) THEN 'active'
+    ELSE 'inactive'
+  END AS status;

--- a/tests/typescript.test.ts
+++ b/tests/typescript.test.ts
@@ -1,0 +1,80 @@
+// Variables and basic types
+let username: string = 'Alice'
+const isActive: boolean = true
+let score: number | undefined
+
+// Arrays, tuples, enums
+const scores: number[] = [10, 20, 30]
+const point: [number, number] = [1, 2]
+
+enum Role {
+  Admin = 'admin',
+  User = 'user',
+  Guest = 'guest',
+}
+
+// Functions with default and optional params
+function greet(name: string = 'World', age?: number): string {
+  return `Hello, ${name}${age ? ` (${age})` : ''}`
+}
+
+// Arrow functions and return type inference
+const double = (x: number): number => {
+  return x * 2
+}
+
+// Interfaces and type aliases
+interface User {
+  id: number
+  name: string
+  email?: string
+  role: Role
+}
+
+type ApiResponse<T> = {
+  data: T
+  error?: string
+}
+
+// Union and intersection types
+type Status = 'pending' | 'success' | 'error'
+type DetailedUser = User & { permissions: string[] }
+
+// Classes with access modifiers, static members, and generics
+class Repository<T> {
+  private items: T[] = []
+
+  add(item: T): void {
+    this.items.push(item)
+  }
+
+  static version: string = '1.0.0'
+
+  getAll(): T[] {
+    return this.items
+  }
+}
+
+// Type assertions and non-null assertions
+const input = document.getElementById('input-name') as HTMLInputElement
+input!.value = 'test'
+
+// Generics with constraints
+function identity<T extends { id: number }>(obj: T): T {
+  return obj
+}
+
+// Await/async + Promise with typed return
+async function fetchData<T>(url: string): Promise<ApiResponse<T>> {
+  const res = await fetch(url)
+  const data = await res.json()
+  return { data }
+}
+
+// Namespaces and module declarations
+namespace Utils {
+  export const version = '1.2.3'
+  export function log(msg: string): void {
+    console.log(`[LOG] ${msg}`)
+  }
+}

--- a/tests/vue.test.vue
+++ b/tests/vue.test.vue
@@ -1,0 +1,114 @@
+<template>
+  <div id="app" class="main">
+    <h1>{{ title }}</h1>
+
+    <input
+      v-model="inputText"
+      type="text"
+      :placeholder="placeholder"
+      @input="handleInput"
+    />
+
+    <button :disabled="isDisabled" @click="submit">Submit</button>
+
+    <ul>
+      <li v-for="(item, index) in items" :key="index">
+        {{ index + 1 }}. {{ item }}
+      </li>
+    </ul>
+
+    <component-a v-if="showComponent" />
+    <component-b v-else />
+
+    <slot name="footer" />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent({
+  name: 'App',
+
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    placeholder: {
+      type: String,
+      default: 'Enter text',
+    },
+  },
+
+  setup(props, { emit }) {
+    const inputText = ref('')
+    const isDisabled = ref(false)
+    const items = ref<string[]>(['Item 1', 'Item 2'])
+    const showComponent = ref(true)
+
+    function handleInput(event: Event) {
+      const target = event.target as HTMLInputElement
+      inputText.value = target.value
+    }
+
+    function submit() {
+      if (inputText.value.trim()) {
+        emit('submit', inputText.value)
+        inputText.value = ''
+      } else {
+        isDisabled.value = true
+      }
+    }
+
+    return {
+      inputText,
+      isDisabled,
+      items,
+      showComponent,
+      handleInput,
+      submit,
+    }
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+#app {
+  padding: 2rem;
+  background: #f9f9f9;
+
+  h1 {
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+  }
+
+  input {
+    padding: 0.5rem;
+    margin-bottom: 1rem;
+    border: 1px solid #ccc;
+  }
+
+  button {
+    padding: 0.5rem 1rem;
+    background-color: blue;
+    color: white;
+    border: none;
+    cursor: pointer;
+
+    &:disabled {
+      background-color: gray;
+      cursor: not-allowed;
+    }
+  }
+
+  ul {
+    list-style-type: none;
+    padding-left: 0;
+
+    li {
+      padding: 0.25rem 0;
+    }
+  }
+}
+</style>

--- a/tests/xml.test.xml
+++ b/tests/xml.test.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Root element with namespaces and attributes -->
+<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0">
+  <!-- Nested elements with attributes -->
+  <user id="123" active="true">
+    <name>John Doe</name>
+    <email>john.doe@example.com</email>
+    <roles>
+      <role>admin</role>
+      <role>editor</role>
+    </roles>
+  </user>
+
+  <!-- Self-closing and empty tags -->
+  <meta />
+  <config value="" />
+
+  <!-- Text content and CDATA -->
+  <description>
+    This is a description with
+    newlines and extra spaces.
+  </description>
+  <raw><![CDATA[
+    <script>alert("xss")</script>
+  ]]></raw>
+
+  <!-- Mixed content and comments -->
+  <note>
+    <to>Toni</to>
+    <from>Bot</from>
+    <message>
+      <!-- Multiline comment -->
+      Hello, this is a
+      <b>bold</b>
+      message.
+    </message>
+  </note>
+
+  <!-- Complex nesting -->
+  <settings>
+    <group name="display">
+      <option key="theme">dark</option>
+      <option key="contrast" />
+    </group>
+    <group name="network">
+      <proxy enabled="true">
+        <host>proxy.example.com</host>
+        <port>8080</port>
+      </proxy>
+    </group>
+  </settings>
+</root>

--- a/tests/yaml.test.yaml
+++ b/tests/yaml.test.yaml
@@ -1,0 +1,81 @@
+# Basic key-value pairs
+name: Prettier Test
+version: '1.0'
+enabled: true
+count: 42
+price: 19.99
+null_value: null
+
+# Nested objects
+user:
+  name: Alice
+  email: alice@example.com
+  roles:
+    - admin
+    - editor
+
+# Multi-level nesting
+server:
+  host: 127.0.0.1
+  port: 8080
+  ssl:
+    enabled: true
+    cert: /etc/ssl/cert.pem
+    key: /etc/ssl/key.pem
+
+# Lists and objects mixed
+items:
+  - name: Item One
+    quantity: 2
+    price: 5.50
+  - name: Item Two
+    quantity: 10
+    price: 1.25
+
+# Flow style (inline)
+flow_map: { one: 1, two: 2 }
+flow_seq: [a, b, c]
+
+# Anchors and aliases
+defaults: &defaults
+  retries: 3
+  timeout: 30s
+
+production:
+  <<: *defaults
+  timeout: 60s
+
+# Multiline strings
+description: >
+  This is a folded block
+  that will be converted into
+  a single line with spaces.
+
+details: |
+  This is a literal block.
+  Line breaks will be preserved.
+  Like this.
+
+# Boolean edge cases
+truthy_values:
+  - true
+  - yes
+  - on
+
+falsy_values:
+  - false
+  - no
+  - off
+
+# Keys with special characters
+'complex key:with symbols': 'value'
+
+# Empty structures
+empty_map: {}
+empty_list: []
+
+# Comments and spacing
+# This is a top-level comment
+config: # This comment follows a key
+  path: /usr/local/bin
+  enabled: true # Extra spacing here


### PR DESCRIPTION
Added:

- A script (`scramble-testfiles.js`) that intentionally scrambles supported test files with safe formatting noise to simulate real-world user errors.
- A `tests/` directory containing one well-structured test file per supported syntax (e.g., CSS, JS, PHP, Markdown, Vue, etc.).

The goal is to verify that after scrambling and reformatting, there are no diffs — ensuring the Prettier extension restores canonical formatting.

This setup supports format-on-save testing and future regression validation.