### PR TITLE
move extract-strings.js to scripts folder in root

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "rollup -c",
-    "extract-strings": "node src/scripts/extract-strings.js",
+    "extract-strings": "node scripts/extract-strings.js",
     "prepare:testfiles": "node scripts/scramble-testfiles.js"
   },
   "repository": {

--- a/scripts/extract-strings.js
+++ b/scripts/extract-strings.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 
 // Project root directory
-const PROJECT_ROOT = path.resolve(__dirname, '../..')
+const PROJECT_ROOT = path.resolve(__dirname, '..')
 const TRANSLATIONS_DIR = path.join(PROJECT_ROOT, 'translations')
 
 const unifiedConfigPath = path.join(PROJECT_ROOT, 'src/unifiedConfig.json')


### PR DESCRIPTION
It is not part of the extension itself, so no need to have it in `src/Scripts`.