### PR TITLE
fix: use correct key to retrieve node-sql-parser options

### DIFF
--- a/src/Scripts/formatter.js
+++ b/src/Scripts/formatter.js
@@ -158,7 +158,7 @@ class Formatter {
       PRETTIER_SQL_PLUGIN_NODE_SQL_PARSER_OPTIONS.map((option) => [
         option,
         getConfigWithWorkspaceOverride(
-          `prettier.plugins.prettier-plugin-sql.sql-formatter.${option}`,
+          `prettier.plugins.prettier-plugin-sql.node-sql-parser.${option}`,
         ),
       ]),
     )


### PR DESCRIPTION
Previously, the extension mistakenly parsed options intended for `sql-formatter` when `node-sql-parser` was selected.