### PR TITLE
centralize Prettier plugin config and simplify option getters

### DIFF
--- a/src/Scripts/helpers.js
+++ b/src/Scripts/helpers.js
@@ -35,6 +35,13 @@ function getConfigWithWorkspaceOverride(name) {
   return workspaceConfig === null ? extensionConfig : workspaceConfig
 }
 
+function pluginEnabled(syntax) {
+  const key = `prettier.plugins.prettier-plugin-${
+    syntax === 'java-properties' ? 'properties' : syntax
+  }.enabled`
+  return getConfigWithWorkspaceOverride(key)
+}
+
 function observeConfigWithWorkspaceOverride(name, fn) {
   let ignored = false
   function wrapped(...args) {
@@ -158,4 +165,5 @@ module.exports = {
   ProcessError,
   handleProcessResult,
   sanitizePrettierConfig,
+  pluginEnabled,
 }


### PR DESCRIPTION
- Consolidated plugin config prefixes and option keys into CONFIG_MAPPINGS
- Dynamically defined all xxxConfig getters in Formatter using _defineConfigGetters()
- Removed repetitive individual get xxxConfig() methods
- Improved maintainability and scalability for adding new plugin configs