### PR TITLE
make sure the bundled Prettier modules are installed

### DIFF
--- a/src/Scripts/module-resolver.js
+++ b/src/Scripts/module-resolver.js
@@ -128,24 +128,9 @@ module.exports = async function () {
   const preferBundled = getConfigWithWorkspaceOverride(
     'prettier.module.preferBundled',
   )
-  if (preferBundled) {
-    try {
-      const prettierPath = nova.path.join(
-        nova.extension.path,
-        'node_modules',
-        'prettier',
-      )
-      log.info(
-        `Using bundled Prettier because "prettier.module.preferBundled" is set: ${prettierPath}`,
-      )
-      return prettierPath
-    } catch (err) {
-      log.warn('Error while resolving bundled Prettier:', err)
-      throw err
-    }
-  }
+
   // Try finding in the workspace
-  if (nova.workspace.path) {
+  if (nova.workspace.path && !preferBundled) {
     // Try finding purely through file system first
     try {
       const fsResult = findModuleWithFileSystem(nova.workspace.path, 'prettier')


### PR DESCRIPTION
When prefering the bundled version we need to make sure that it is actually installed.