### PR TITLE
Add command to manually restart Prettier service

### DIFF
--- a/prettier.novaextension/extension.json
+++ b/prettier.novaextension/extension.json
@@ -86,7 +86,12 @@
     ],
     "extensions": [
       {
-        "title": "Reset Syntax Warnings for Prettier+",
+        "title": "Restart Prettier Service",
+        "command": "prettier.restart-service",
+        "shortcut": "cmd-ctrl-shift-r"
+      },
+      {
+        "title": "Reset Syntax Warnings",
         "command": "prettier.reset-suppressed-message"
       }
     ]

--- a/src/Scripts/main.js
+++ b/src/Scripts/main.js
@@ -122,6 +122,12 @@ class PrettierExtension {
       'prettier.save-without-formatting',
       this.didInvokeSaveWithoutFormattingCommand,
     )
+
+    nova.commands.register(
+      'prettier.restart-service',
+      this.modulePathDidChange,
+    )
+
     nova.commands.register('prettier.reset-suppressed-message', () => {
       nova.config.remove('prettier.selection-unsupported.dismissed')
       nova.workspace.context.set(

--- a/src/Scripts/main.js
+++ b/src/Scripts/main.js
@@ -123,10 +123,7 @@ class PrettierExtension {
       this.didInvokeSaveWithoutFormattingCommand,
     )
 
-    nova.commands.register(
-      'prettier.restart-service',
-      this.modulePathDidChange,
-    )
+    nova.commands.register('prettier.restart-service', this.modulePathDidChange)
 
     nova.commands.register('prettier.reset-suppressed-message', () => {
       nova.config.remove('prettier.selection-unsupported.dismissed')

--- a/translations/de.lproj/strings.json
+++ b/translations/de.lproj/strings.json
@@ -237,5 +237,6 @@
   "Format Selection": "Auswahl formatieren",
   "Format Document (Forced)": "",
   "Save Without Formatting": "Speichern ohne Formatierung",
-  "Reset Syntax Warnings for Prettier+": "Syntax-Warnungen für Prettier+ zurücksetzen"
+  "Restart Prettier Service": "",
+  "Reset Syntax Warnings": ""
 }

--- a/translations/en.lproj/strings.json
+++ b/translations/en.lproj/strings.json
@@ -237,5 +237,6 @@
   "Format Selection": "Format Selection",
   "Format Document (Forced)": "Format Document (Forced)",
   "Save Without Formatting": "Save Without Formatting",
-  "Reset Syntax Warnings for Prettier+": "Reset Syntax Warnings for Prettier+"
+  "Restart Prettier Service": "Restart Prettier Service",
+  "Reset Syntax Warnings": "Reset Syntax Warnings"
 }

--- a/translations/fr.lproj/strings.json
+++ b/translations/fr.lproj/strings.json
@@ -237,5 +237,6 @@
   "Format Selection": "",
   "Format Document (Forced)": "",
   "Save Without Formatting": "",
-  "Reset Syntax Warnings for Prettier+": ""
+  "Restart Prettier Service": "",
+  "Reset Syntax Warnings": ""
 }

--- a/translations/jp.lproj/strings.json
+++ b/translations/jp.lproj/strings.json
@@ -237,5 +237,6 @@
   "Format Selection": "",
   "Format Document (Forced)": "",
   "Save Without Formatting": "",
-  "Reset Syntax Warnings for Prettier+": ""
+  "Restart Prettier Service": "",
+  "Reset Syntax Warnings": ""
 }

--- a/translations/zh-Hans.lproj/strings.json
+++ b/translations/zh-Hans.lproj/strings.json
@@ -237,5 +237,6 @@
   "Format Selection": "",
   "Format Document (Forced)": "",
   "Save Without Formatting": "",
-  "Reset Syntax Warnings for Prettier+": ""
+  "Restart Prettier Service": "",
+  "Reset Syntax Warnings": ""
 }


### PR DESCRIPTION
Adds a new “Restart Prettier Service” command to the Extensions menu, allowing users to manually trigger a service restart when needed.