### PR TITLE
feat: Babel AST extraction & multi-table localization support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,128 @@
       "version": "3.5.21",
       "license": "MIT",
       "devDependencies": {
+        "@babel/parser": "^7.27.0",
+        "@babel/traverse": "^7.27.0",
         "@rollup/plugin-commonjs": "^28.0.3",
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-terser": "^0.4.4",
         "rollup": "^4.40.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
+      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.27.0",
+        "@babel/parser": "^7.27.0",
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -505,6 +623,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -562,6 +698,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -608,6 +754,26 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -618,12 +784,26 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "strings:extract": "node scripts/extract-strings.js"
   },
   "devDependencies": {
+    "@babel/parser": "^7.27.0",
+    "@babel/traverse": "^7.27.0",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.4",

--- a/scripts/extract-strings.js
+++ b/scripts/extract-strings.js
@@ -5,8 +5,14 @@
  * @author Toni Förster
  * @copyright © 2025 Toni Förster
  *
- * Scans unified configuration and extension metadata to collect all user-visible
- * strings for translation. Merges with existing entries per language.
+ * Scans unified configuration and extension metadata as well as source files for
+ * all user-visible strings for translation. Merges with existing entries per language.
+ *
+ * Uses key/table approach so that calls like:
+ *
+ *   nova.localize('prettier.notification.config.updated.title', 'Project Configuration Updated', 'notification')
+ *
+ * will be stored in "notification.json", while others go into "strings.json".
  */
 
 const fs = require('fs')
@@ -15,6 +21,7 @@ const path = require('path')
 // Project root directory
 const PROJECT_ROOT = path.resolve(__dirname, '..')
 const TRANSLATIONS_DIR = path.join(PROJECT_ROOT, 'translations')
+const SCRIPTS_DIR = path.join(PROJECT_ROOT, 'src', 'Scripts')
 
 const unifiedConfigPath = path.join(PROJECT_ROOT, 'src/unifiedConfig.json')
 const extensionJsonPath = path.join(
@@ -22,6 +29,7 @@ const extensionJsonPath = path.join(
   'prettier.novaextension/extension.json',
 )
 
+// Languages to output translations for
 const languages = [
   'de.lproj',
   'en.lproj',
@@ -30,54 +38,59 @@ const languages = [
   'zh-Hans.lproj',
 ]
 
-const result = {}
-
-function extractTranslatableValues(config, configWorkspace) {
-  if (!Array.isArray(configWorkspace?.values)) return
-
-  const workspaceValues = configWorkspace.values
-  const baseValues = new Set(
-    Array.isArray(config?.values)
-      ? config.values.map((v) => (Array.isArray(v) ? v[0] : v))
-      : [],
-  )
-
-  for (const item of workspaceValues) {
-    const key = Array.isArray(item) ? item[0] : item
-    const label = Array.isArray(item) ? item[1] : item
-
-    if (!baseValues.has(key)) {
-      result[label] = label
-    } else {
-      console.log(`🔁 Skipping "${label}"`)
-    }
-  }
+// Global results object, keyed by table name.
+// Any extraction without a specified table goes to the default "strings" table.
+const results = {
+  strings: {},
 }
 
 // ─────────────────────────────────────────
-// Parse unifiedConfig.json
+// Extraction from unifiedConfig.json
 if (fs.existsSync(unifiedConfigPath)) {
   const unifiedConfig = JSON.parse(fs.readFileSync(unifiedConfigPath, 'utf8'))
 
+  function extractTranslatableValues(config, configWorkspace) {
+    if (!Array.isArray(configWorkspace?.values)) return
+
+    const workspaceValues = configWorkspace.values
+    const baseValues = new Set(
+      Array.isArray(config?.values)
+        ? config.values.map((v) => (Array.isArray(v) ? v[0] : v))
+        : [],
+    )
+
+    for (const item of workspaceValues) {
+      const key = Array.isArray(item) ? item[0] : item
+      const label = Array.isArray(item) ? item[1] : item
+
+      if (!baseValues.has(key)) {
+        results.strings[label] = label
+      } else {
+        console.log(`🔁 Skipping "${label}"`)
+      }
+    }
+  }
+
   function extractFromUnified(nodes) {
     for (const node of nodes) {
-      if (node.title) result[node.title] = node.title
-      if (node.description) result[node.description] = node.description
-      if (node.placeholder) result[node.placeholder] = node.placeholder
+      if (node.title) results.strings[node.title] = node.title
+      if (node.description) results.strings[node.description] = node.description
+      if (node.placeholder) results.strings[node.placeholder] = node.placeholder
 
-      if (node.config?.title) result[node.config.title] = node.config.title
+      if (node.config?.title)
+        results.strings[node.config.title] = node.config.title
       if (node.config?.description)
-        result[node.config.description] = node.config.description
+        results.strings[node.config.description] = node.config.description
       if (node.config?.placeholder)
-        result[node.config.placeholder] = node.config.placeholder
+        results.strings[node.config.placeholder] = node.config.placeholder
 
       if (node.configWorkspace?.title)
-        result[node.configWorkspace.title] = node.configWorkspace.title
+        results.strings[node.configWorkspace.title] = node.configWorkspace.title
       if (node.configWorkspace?.description)
-        result[node.configWorkspace.description] =
+        results.strings[node.configWorkspace.description] =
           node.configWorkspace.description
       if (node.configWorkspace?.placeholder)
-        result[node.configWorkspace.placeholder] =
+        results.strings[node.configWorkspace.placeholder] =
           node.configWorkspace.placeholder
 
       extractTranslatableValues(node.config, node.configWorkspace)
@@ -86,7 +99,7 @@ if (fs.existsSync(unifiedConfigPath)) {
       if (node.config?.values && Array.isArray(node.config.values)) {
         for (const tuple of node.config.values) {
           if (Array.isArray(tuple) && tuple.length > 1 && tuple[1])
-            result[tuple[1]] = tuple[1]
+            results.strings[tuple[1]] = tuple[1]
         }
       }
 
@@ -97,7 +110,7 @@ if (fs.existsSync(unifiedConfigPath)) {
       ) {
         for (const tuple of node.configWorkspace.values) {
           if (Array.isArray(tuple) && tuple.length > 1 && tuple[1])
-            result[tuple[1]] = tuple[1]
+            results.strings[tuple[1]] = tuple[1]
         }
       }
 
@@ -109,48 +122,131 @@ if (fs.existsSync(unifiedConfigPath)) {
 }
 
 // ─────────────────────────────────────────
-// Parse extension.json
+// Extraction from extension.json
 if (fs.existsSync(extensionJsonPath)) {
   const ext = JSON.parse(fs.readFileSync(extensionJsonPath, 'utf8'))
 
   // Extract root-level keys
-  if (ext.description) result[ext.description] = ext.description
+  if (ext.description) results.strings[ext.description] = ext.description
 
   const commandSections = ext.commands || {}
   for (const section of Object.values(commandSections)) {
     for (const cmd of section) {
-      if (cmd.title) result[cmd.title] = cmd.title
-      if (cmd.description) result[cmd.description] = cmd.description
+      if (cmd.title) results.strings[cmd.title] = cmd.title
+      if (cmd.description) results.strings[cmd.description] = cmd.description
     }
   }
 }
 
 // ─────────────────────────────────────────
-// Write to each language's strings.json in /translations
-languages.forEach((lang) => {
-  const langDir = path.join(TRANSLATIONS_DIR, lang)
-  const outputPath = path.join(langDir, 'strings.json')
+// Extract nova.localize() strings from src/Scripts using AST
+const parser = require('@babel/parser')
+const traverse = require('@babel/traverse').default
 
-  fs.mkdirSync(langDir, { recursive: true })
+function extractNotificationKeysAST(filePath) {
+  const code = fs.readFileSync(filePath, 'utf8')
+  const ast = parser.parse(code, {
+    sourceType: 'module',
+    // Add plugins as needed (e.g. 'jsx', 'typescript')
+    plugins: ['jsx', 'typescript'],
+  })
 
-  let existing = {}
-  if (fs.existsSync(outputPath)) {
-    try {
-      existing = JSON.parse(fs.readFileSync(outputPath, 'utf8'))
-    } catch (e) {
-      console.warn(`⚠️ Could not parse ${lang}/strings.json — skipping merge`)
+  traverse(ast, {
+    CallExpression({ node }) {
+      // Check if the call is nova.localize(...)
+      if (
+        node.callee &&
+        node.callee.type === 'MemberExpression' &&
+        node.callee.object.name === 'nova' &&
+        node.callee.property.name === 'localize'
+      ) {
+        const args = node.arguments
+        // Ensure we have at least 2 arguments (key and fallback)
+        if (
+          args.length >= 2 &&
+          args[0].type === 'StringLiteral' &&
+          args[1].type === 'StringLiteral'
+        ) {
+          const key = args[0].value
+          const fallback = args[1].value
+          // Default table is "strings"
+          let tableName = 'strings'
+          // If a third argument is provided and is a string literal, use that as the table name
+          if (
+            args.length >= 3 &&
+            args[2].type === 'StringLiteral' &&
+            args[2].value
+          ) {
+            tableName = args[2].value
+          }
+          // Ensure the table exists in our results object
+          if (!results[tableName]) {
+            results[tableName] = {}
+          }
+          results[tableName][key] = fallback
+
+          console.log(
+            `Extracted key "${key}" with fallback "${fallback}" into table "${tableName}"`,
+          )
+        }
+      }
+    },
+  })
+}
+
+function extractNotificationKeysFromDir(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      extractNotificationKeysFromDir(fullPath)
+    } else if (
+      entry.isFile() &&
+      (fullPath.endsWith('.js') ||
+        fullPath.endsWith('.jsx') ||
+        fullPath.endsWith('.ts'))
+    ) {
+      extractNotificationKeysAST(fullPath)
     }
   }
+}
 
-  const merged = Object.fromEntries(
-    Object.keys(result).map((key) => [
-      key,
-      existing[key] ?? (lang === 'en.lproj' ? result[key] : ''),
-    ]),
-  )
+if (fs.existsSync(SCRIPTS_DIR)) {
+  extractNotificationKeysFromDir(SCRIPTS_DIR)
+}
 
-  fs.writeFileSync(outputPath, JSON.stringify(merged, null, 2) + '\n')
-  console.log(
-    `✅ Wrote ${Object.keys(merged).length} strings to translations/${lang}/strings.json`,
-  )
+// ─────────────────────────────────────────
+// Write out translations to separate files per table (e.g. strings.json, notification.json)
+// For each language, create a separate JSON file for each table in results.
+languages.forEach((lang) => {
+  const langDir = path.join(TRANSLATIONS_DIR, lang)
+  fs.mkdirSync(langDir, { recursive: true })
+
+  for (const tableName in results) {
+    const outputPath = path.join(langDir, tableName + '.json')
+
+    let existing = {}
+    if (fs.existsSync(outputPath)) {
+      try {
+        existing = JSON.parse(fs.readFileSync(outputPath, 'utf8'))
+      } catch (e) {
+        console.warn(
+          `⚠️ Could not parse ${lang}/${tableName}.json — skipping merge`,
+        )
+      }
+    }
+
+    const merged = Object.fromEntries(
+      Object.keys(results[tableName]).map((key) => [
+        key,
+        // For English, always use the fallback; for other languages, use fallback if no translation exists.
+        existing[key] ?? (lang === 'en.lproj' ? results[tableName][key] : ''),
+      ]),
+    )
+
+    fs.writeFileSync(outputPath, JSON.stringify(merged, null, 2) + '\n')
+    console.log(
+      `✅ Wrote ${Object.keys(merged).length} strings to translations/${lang}/${tableName}.json`,
+    )
+  }
 })

--- a/src/Scripts/formatter.js
+++ b/src/Scripts/formatter.js
@@ -398,8 +398,8 @@ class Formatter {
       if (!saving) {
         showError(
           'prettier-unsupported-syntax',
-          `Syntax Not Supported`,
-          `Prettier doesn't include a parser for this file, and no installed plugin provides one.`,
+          'Syntax Not Supported',
+          'Prettier doesn’t include a parser for this file, and no installed plugin provides one.',
         )
       }
       log.info(`No parser for ${document.path}`)

--- a/src/Scripts/helpers.js
+++ b/src/Scripts/helpers.js
@@ -18,9 +18,15 @@ class ProcessError extends Error {
 function showError(id, title, body) {
   let request = new NotificationRequest(id)
 
-  request.title = nova.localize(title)
-  request.body = nova.localize(body)
-  request.actions = [nova.localize('OK')]
+  request.title = title
+  request.body = body
+  request.actions = [
+    nova.localize(
+      'prettier.notification.showErrors.actions',
+      'OK',
+      'notification',
+    ),
+  ]
 
   nova.notifications.add(request).catch((err) => console.error(err, err.stack))
 }
@@ -28,9 +34,9 @@ function showError(id, title, body) {
 function showActionableError(id, title, body, actions, callback) {
   let request = new NotificationRequest(id)
 
-  request.title = nova.localize(title)
-  request.body = nova.localize(body)
-  request.actions = actions.map((action) => nova.localize(action))
+  request.title = title
+  request.body = body
+  request.actions = actions.map((action) => action)
 
   nova.notifications
     .add(request)
@@ -145,10 +151,23 @@ async function sanitizePrettierConfig() {
 
       // Send a notification if values have been changed.
       let notification = new NotificationRequest('prettier-config-updated')
-      notification.title = 'Project Configuration Updated'
-      notification.body =
-        "Your project's Prettier configuration has been updated to the new config format."
-      notification.actions = ['OK']
+      notification.title = nova.localize(
+        'prettier.notification.config.updated.title',
+        'Project Configuration Updated',
+        'notification',
+      )
+      notification.body = nova.localize(
+        'prettier.notification.config.updated.body',
+        'Your project’s Prettier configuration has been updated to the new config format.',
+        'notification',
+      )
+      notification.actions = [
+        nova.localize(
+          'prettier.notification.config.updated.actions',
+          'OK',
+          'notification',
+        ),
+      ]
       await nova.notifications.add(notification)
       console.info('Notification sent.')
     } else {

--- a/src/Scripts/main.js
+++ b/src/Scripts/main.js
@@ -134,7 +134,9 @@ class PrettierExtension {
       )
       nova.workspace.showInformativeMessage(
         nova.localize(
+          'prettier.notification.formatSelection.restored.message',
           'Prettier⁺ notification restored. “Format Selection” will now reappear in the menu for unsupported syntaxes, showing a warning when used.',
+          'notification',
         ),
       )
     })
@@ -194,8 +196,8 @@ class PrettierExtension {
       if (err.status === 127) {
         return showError(
           'prettier-resolution-error',
-          `Can't find npm and Prettier`,
-          `Prettier couldn't be found because npm isn't available. Please make sure you have Node installed. If you've only installed Node through NVM, you'll need to change your shell configuration to work with Nova. See https://library.panic.com/nova/environment-variables/`,
+          'Can’t find npm and Prettier',
+          'Prettier couldn’t be found because npm isn’t available. Please make sure you have Node installed. If you’ve only installed Node through NVM, you’ll need to change your shell configuration to work with Nova. See https://library.panic.com/nova/environment-variables/',
         )
       }
 
@@ -203,8 +205,8 @@ class PrettierExtension {
 
       return showError(
         'prettier-resolution-error',
-        `Unable to start Prettier`,
-        `Please check the extension console for additional logs.`,
+        'Unable to start Prettier',
+        'Please check the extension console for additional logs.',
       )
     }
   }
@@ -235,7 +237,7 @@ class PrettierExtension {
       console.error(err, err.stack)
       showError(
         'prettier-format-error',
-        `Error while forcibly formatting`,
+        'Error while forcibly formatting',
         `"${err.message}" occurred while forcibly formatting ${editor.document.path}. See the extension console for more info.`,
       )
     }
@@ -259,11 +261,28 @@ class PrettierExtension {
       if (dismissed === true) return
 
       let req = new NotificationRequest('prettier-selection-unsupported')
-      req.title = nova.localize('Unsupported Syntax')
-      req.body = nova.localize(
-        '“Format Selection” isn’t available for this file type. Supported syntaxes: JavaScript, TypeScript, GraphQL, and Handlebars.\n\nClicking “Dismiss” will disable the command for unsupported syntaxes.',
+      req.title = nova.localize(
+        'prettier.notification.unsupportedSyntax.title',
+        'Unsupported Syntax',
+        'notification',
       )
-      req.actions = [nova.localize('OK'), nova.localize('Dismiss')]
+      req.body = nova.localize(
+        'prettier.notification.unsupportedSyntax.body',
+        '“Format Selection” isn’t available for this file type. Supported syntaxes: JavaScript, TypeScript, GraphQL, and Handlebars.\n\nClicking “Dismiss” will disable the command for unsupported syntaxes.',
+        'notification',
+      )
+      req.actions = [
+        nova.localize(
+          'prettier.notification.unsupportedSyntax.actions.ok',
+          'OK',
+          'notification',
+        ),
+        nova.localize(
+          'prettier.notification.unsupportedSyntax.actions.dismiss',
+          'Dismiss',
+          'notification',
+        ),
+      ]
 
       nova.notifications
         .add(req)

--- a/src/Scripts/module-resolver.js
+++ b/src/Scripts/module-resolver.js
@@ -89,7 +89,7 @@ async function findModuleWithNPM(directory, module) {
     if (!name || !name.startsWith(`${module}@`)) return resolve(null)
     if (path === nova.workspace.path) {
       log.info(
-        `You seem to be working on ${module}! The extension doesn't work without ${module} built, so using the built-in ${module} instead.`,
+        `You seem to be working on ${module}! The extension doesn’t work without ${module} built, so using the built-in ${module} instead.`,
       )
       return resolve(null)
     }

--- a/translations/de.lproj/notification.json
+++ b/translations/de.lproj/notification.json
@@ -1,0 +1,11 @@
+{
+  "prettier.notification.showErrors.actions": "",
+  "prettier.notification.config.updated.title": "",
+  "prettier.notification.config.updated.body": "",
+  "prettier.notification.config.updated.actions": "",
+  "prettier.notification.formatSelection.restored.message": "",
+  "prettier.notification.unsupportedSyntax.title": "",
+  "prettier.notification.unsupportedSyntax.body": "",
+  "prettier.notification.unsupportedSyntax.actions.ok": "",
+  "prettier.notification.unsupportedSyntax.actions.dismiss": ""
+}

--- a/translations/en.lproj/notification.json
+++ b/translations/en.lproj/notification.json
@@ -1,0 +1,11 @@
+{
+  "prettier.notification.showErrors.actions": "OK",
+  "prettier.notification.config.updated.title": "Project Configuration Updated",
+  "prettier.notification.config.updated.body": "Your project’s Prettier configuration has been updated to the new config format.",
+  "prettier.notification.config.updated.actions": "OK",
+  "prettier.notification.formatSelection.restored.message": "Prettier⁺ notification restored. “Format Selection” will now reappear in the menu for unsupported syntaxes, showing a warning when used.",
+  "prettier.notification.unsupportedSyntax.title": "Unsupported Syntax",
+  "prettier.notification.unsupportedSyntax.body": "“Format Selection” isn’t available for this file type. Supported syntaxes: JavaScript, TypeScript, GraphQL, and Handlebars.\n\nClicking “Dismiss” will disable the command for unsupported syntaxes.",
+  "prettier.notification.unsupportedSyntax.actions.ok": "OK",
+  "prettier.notification.unsupportedSyntax.actions.dismiss": "Dismiss"
+}

--- a/translations/fr.lproj/notification.json
+++ b/translations/fr.lproj/notification.json
@@ -1,0 +1,11 @@
+{
+  "prettier.notification.showErrors.actions": "",
+  "prettier.notification.config.updated.title": "",
+  "prettier.notification.config.updated.body": "",
+  "prettier.notification.config.updated.actions": "",
+  "prettier.notification.formatSelection.restored.message": "",
+  "prettier.notification.unsupportedSyntax.title": "",
+  "prettier.notification.unsupportedSyntax.body": "",
+  "prettier.notification.unsupportedSyntax.actions.ok": "",
+  "prettier.notification.unsupportedSyntax.actions.dismiss": ""
+}

--- a/translations/jp.lproj/notification.json
+++ b/translations/jp.lproj/notification.json
@@ -1,0 +1,11 @@
+{
+  "prettier.notification.showErrors.actions": "",
+  "prettier.notification.config.updated.title": "",
+  "prettier.notification.config.updated.body": "",
+  "prettier.notification.config.updated.actions": "",
+  "prettier.notification.formatSelection.restored.message": "",
+  "prettier.notification.unsupportedSyntax.title": "",
+  "prettier.notification.unsupportedSyntax.body": "",
+  "prettier.notification.unsupportedSyntax.actions.ok": "",
+  "prettier.notification.unsupportedSyntax.actions.dismiss": ""
+}

--- a/translations/zh-Hans.lproj/notification.json
+++ b/translations/zh-Hans.lproj/notification.json
@@ -1,0 +1,11 @@
+{
+  "prettier.notification.showErrors.actions": "",
+  "prettier.notification.config.updated.title": "",
+  "prettier.notification.config.updated.body": "",
+  "prettier.notification.config.updated.actions": "",
+  "prettier.notification.formatSelection.restored.message": "",
+  "prettier.notification.unsupportedSyntax.title": "",
+  "prettier.notification.unsupportedSyntax.body": "",
+  "prettier.notification.unsupportedSyntax.actions.ok": "",
+  "prettier.notification.unsupportedSyntax.actions.dismiss": ""
+}


### PR DESCRIPTION
- Use Babel AST-based approach to reliably extract nova.localize() calls.
- Support key/table logic so that calls with a third parameter are stored in dedicated JSON files (e.g. notification.json), while others go into strings.json.
- Update extraction to merge unified configuration and extension metadata into the default table.
- Add @babel/parser and @babel/traverse as dependencies for robust code parsing.