### PR TITLE
revert: update extract-strings.js to handle TemplateLiterals

### DIFF
--- a/scripts/extract-strings.js
+++ b/scripts/extract-strings.js
@@ -165,25 +165,10 @@ function extractNotificationKeysAST(filePath) {
         if (
           args.length >= 2 &&
           args[0].type === 'StringLiteral' &&
-          (args[1].type === 'StringLiteral' ||
-            args[1].type === 'TemplateLiteral')
+          args[1].type === 'StringLiteral'
         ) {
           const key = args[0].value
-          let fallback = ''
-
-          if (args[1].type === 'StringLiteral') {
-            fallback = args[1].value
-          } else if (args[1].type === 'TemplateLiteral') {
-            // Combine the literal parts and insert placeholders for the expressions
-            fallback = args[1].quasis
-              .map((elem, i) => {
-                const expressionPlaceholder = args[1].expressions[i]
-                  ? '${...}'
-                  : ''
-                return elem.value.cooked + expressionPlaceholder
-              })
-              .join('')
-          }
+          const fallback = args[1].value
           // Default table is "strings"
           let tableName = 'strings'
           // If a third argument is provided and is a string literal, use that as the table name

--- a/scripts/extract-strings.js
+++ b/scripts/extract-strings.js
@@ -165,6 +165,8 @@ function extractNotificationKeysAST(filePath) {
         if (
           args.length >= 2 &&
           args[0].type === 'StringLiteral' &&
+          // Only string literals are supported as fallback values. This is intentional to avoid
+          // handling dynamic runtime expressions in the translation extraction process.
           args[1].type === 'StringLiteral'
         ) {
           const key = args[0].value

--- a/src/Scripts/main.js
+++ b/src/Scripts/main.js
@@ -277,11 +277,12 @@ class PrettierExtension {
           'Error While Formatting',
           'notification',
         ),
-        nova.localize(
-          'prettier.notification.format-error.body',
-          `"${err.message}" occurred while formatting ${editor.document.path}. See the extension console for more info.`,
-          'notification',
-        ),
+        `"${err.message}"` +
+          nova.localize(
+            'prettier.notification.format-error.body',
+            '\n\nSee the Extension Console for more info.',
+            'notification',
+          ),
       )
     }
   }
@@ -370,11 +371,12 @@ class PrettierExtension {
           'Error While Formatting',
           'notification',
         ),
-        nova.localize(
-          'prettier.notification.format-error.body',
-          `"${err.message}" occurred while formatting ${editor.document.path}. See the extension console for more info.`,
-          'notification',
-        ),
+        `"${err.message}"` +
+          nova.localize(
+            'prettier.notification.format-error.body',
+            '\n\nSee the Extension Console for more info.',
+            'notification',
+          ),
       )
     }
   }

--- a/translations/en.lproj/notification.json
+++ b/translations/en.lproj/notification.json
@@ -18,7 +18,7 @@
   "prettier.notification.prettier-start-failed.title": "Unable to Start Prettier",
   "prettier.notification.prettier-start-failed.body": "Please check the extension console for additional logs.",
   "prettier.notification.format-error.title": "Error While Formatting",
-  "prettier.notification.format-error.body": "\"${...}\" occurred while formatting ${...}. See the extension console for more info.",
+  "prettier.notification.format-error.body": "\n\nSee the Extension Console for more info.",
   "prettier.notification.unsupportedSyntax.body": "“Format Selection” isn’t available for this file type. Supported syntaxes: JavaScript, TypeScript, GraphQL, and Handlebars.\n\nClicking “Dismiss” will disable the command for unsupported syntaxes.",
   "prettier.notification.actions.dismiss": "Dismiss"
 }


### PR DESCRIPTION
We need to construct these strings differently, to not lose the runtime values