### PR TITLE
add support for Nova's SQL Language Extension

### DIFF
--- a/src/Scripts/formatter.js
+++ b/src/Scripts/formatter.js
@@ -33,7 +33,10 @@ const {
 
 const { detectSyntax } = require('./syntax.js')
 
-const { getSqlDialectFromUri, getSqlParserDialect } = require('./sql.js')
+const {
+  getSqlDialectFromUriOrSyntax,
+  getSqlParserDialect,
+} = require('./sql.js')
 
 class Formatter {
   constructor() {
@@ -507,7 +510,10 @@ class Formatter {
           const config = { ...this.sqlFormatterConfig }
 
           if (config.language === 'auto') {
-            config.language = getSqlDialectFromUri(document.uri)
+            config.language = getSqlDialectFromUriOrSyntax(
+              document.uri,
+              document.syntax,
+            )
             log.debug(`Auto-detected SQL dialect: ${config.language}`)
           }
 
@@ -516,7 +522,7 @@ class Formatter {
           const config = { ...this.nodeSqlParserConfig }
 
           if (config.database === 'auto') {
-            config.database = getSqlParserDialect(document.uri)
+            config.database = getSqlParserDialect(document.uri, document.syntax)
             log.debug(`Using node-sql-parser dialect: ${config.database}`)
           }
 

--- a/src/Scripts/syntax.js
+++ b/src/Scripts/syntax.js
@@ -151,6 +151,26 @@ const sortedExtensions = Object.keys(extToSyntax).sort(
   (a, b) => b.length - a.length,
 )
 
+// 2.5) If Nova reports a SQL-dialect-specific syntax, normalize it to "sql"
+//      These are only reported when the SQL Language Extension is installed.
+const sqlAliases = new Set([
+  'sparksql',
+  'snowflake',
+  'singlestore',
+  'redshift',
+  'postgresql',
+  'plsql',
+  'mysql',
+  'hivesql',
+  'flinksql',
+  'bigquery',
+  'tsql',
+  'trino',
+  'sqlpl',
+  'sqlite',
+  'sql-generic',
+])
+
 // 3) Nova’s built‑in syntax keys we explicitly support
 const knownSyntaxKeys = new Set([
   'astro',
@@ -207,6 +227,10 @@ function detectSyntax({ syntax, uri }) {
     syntax === 'liquid-html'
   ) {
     return syntax
+  }
+  // 0) SQLexceptions: if Nova got it right, trust it immediately
+  if (sqlAliases.has(syntax)) {
+    return 'sql'
   }
 
   // 1) Extension‑based detection (longest suffix first)


### PR DESCRIPTION
When Nova's SQL Language extension is installed, use the provided syntax for dialect detection instead of resolving via the URI.