### PR TITLE
Improve service lifecycle, debouncing and logging

### DIFF
--- a/prettier.novaextension/package-lock.json
+++ b/prettier.novaextension/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@prettier/plugin-php": "^0.22.4",
         "@prettier/plugin-xml": "^3.4.1",
-        "@shopify/prettier-plugin-liquid": "^1.9.2",
+        "@shopify/prettier-plugin-liquid": "^1.9.3",
         "@shufo/prettier-plugin-blade": "^1.15.3",
         "@zackad/prettier-plugin-twig": "^0.16.0",
         "patch-package": "^8.0.0",
@@ -392,9 +392,9 @@
       }
     },
     "node_modules/@shopify/liquid-html-parser": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@shopify/liquid-html-parser/-/liquid-html-parser-2.8.1.tgz",
-      "integrity": "sha512-+uXoVsxcry7w77Er/spothOfhzodvbvSGdULl/l2bdgvQwn/6FhomJn1D6vuPzdyuYfOBUmVMyvt1cgooqzgYg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@shopify/liquid-html-parser/-/liquid-html-parser-2.8.2.tgz",
+      "integrity": "sha512-g8DRcz4wUj4Ttxm+rK1qPuvIV2/ZqlyGRcVytVMbUkrr/+eVL2yQI/jRGDMeOamkRqB3InuoOjF7nARH+o9UYQ==",
       "license": "MIT",
       "dependencies": {
         "line-column": "^1.0.2",
@@ -402,12 +402,12 @@
       }
     },
     "node_modules/@shopify/prettier-plugin-liquid": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@shopify/prettier-plugin-liquid/-/prettier-plugin-liquid-1.9.2.tgz",
-      "integrity": "sha512-T9XVzAUqBUFgPIzGpDJzwJMsoneA+3twKWNy2HMdcHHhZ/Ok1O+GSsci8nlkoPlcfPcFEjJQH1kEuoL6DIDR/w==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@shopify/prettier-plugin-liquid/-/prettier-plugin-liquid-1.9.3.tgz",
+      "integrity": "sha512-XRRnwfONrzjW8AY/l39szH9OgCCg5Xx61QxxdrC3BT2RAqo229jomjhCEszGIUJ5YZYq1ewdyBwbvUVTUSTcTg==",
       "license": "MIT",
       "dependencies": {
-        "@shopify/liquid-html-parser": "^2.8.1",
+        "@shopify/liquid-html-parser": "^2.8.2",
         "html-styles": "^1.0.0"
       },
       "peerDependencies": {

--- a/prettier.novaextension/package.json
+++ b/prettier.novaextension/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@prettier/plugin-php": "^0.22.4",
     "@prettier/plugin-xml": "^3.4.1",
-    "@shopify/prettier-plugin-liquid": "^1.9.2",
+    "@shopify/prettier-plugin-liquid": "^1.9.3",
     "@shufo/prettier-plugin-blade": "^1.15.3",
     "@zackad/prettier-plugin-twig": "^0.16.0",
     "patch-package": "^8.0.0",

--- a/src/Scripts/helpers.js
+++ b/src/Scripts/helpers.js
@@ -199,6 +199,26 @@ async function sanitizePrettierConfig() {
   }
 }
 
+function debouncePromise(fn, timeoutMs) {
+  let timer = null
+
+  const debounced = (...args) => {
+    clearTimeout(timer)
+    timer = setTimeout(() => {
+      Promise.resolve(fn(...args)).finally(() => {
+        timer = null
+      })
+    }, timeoutMs)
+  }
+
+  debounced.cancel = () => {
+    clearTimeout(timer)
+    timer = null
+  }
+
+  return debounced
+}
+
 module.exports = {
   extractPath,
   showError,
@@ -210,4 +230,5 @@ module.exports = {
   ProcessError,
   handleProcessResult,
   sanitizePrettierConfig,
+  debouncePromise,
 }

--- a/src/Scripts/module-resolver.js
+++ b/src/Scripts/module-resolver.js
@@ -227,11 +227,11 @@ module.exports = async function () {
     }
 
     if (installReason) {
-      log.info(`Running npm install due to: ${installReason}`)
+      log.info('Running npm install due to: ', installReason)
       await installPackages(nova.extension.path)
     }
 
-    log.info(`Loading bundled prettier from ${prettierPath}`)
+    log.info('Using bundled Prettier.')
     return prettierPath
   } catch (err) {
     if (err.status === 127) throw err

--- a/src/Scripts/prettier-service/prettier-service.js
+++ b/src/Scripts/prettier-service/prettier-service.js
@@ -157,3 +157,24 @@ try {
   })
   process.exit()
 }
+
+const shutdown = async () => {
+  // if dispose() returns a promise, wait for it (swallow any errors)
+  try {
+    await jsonRpcService.dispose?.()
+  } catch (_) {}
+
+  // ensure stdio pipes don’t keep Node alive
+  try {
+    process.stdin.destroy()
+  } catch (_) {}
+  try {
+    process.stdout.destroy()
+  } catch (_) {}
+
+  // force exit
+  process.exit(0)
+}
+
+// bind it once for each signal
+;['SIGTERM', 'SIGINT'].forEach((signal) => process.once(signal, shutdown))


### PR DESCRIPTION
- Introduce `debouncePromise` helper (and fast variant) to throttle all calls to `modulePathDidChange`, with separate  delays for file‐watch and config/UI triggers
- Enhance `stop()`:
  - Log “Stopping Prettier service…” and measure actual shutdown time with `log.info`
  - Fall back to force‐resolve after 5s if process hasn’t exited
- Refine `prettierServiceDidExit`:
  - Don’t restart on clean exit (exit code 0)
  - Only auto–restart on crash once, with a 5s “crashed recently” guard
- Harden shutdown in `prettier-service.js`:
  - Use `process.once` for SIGTERM/SIGINT
  - `await jsonRpcService.dispose?.()`, destroy `stdin`/`stdout`, then `process.exit(0)`