### PR TITLE
feat: add error dialog for missing runtime tools

### DIFF
--- a/translations/de.lproj/notification.json
+++ b/translations/de.lproj/notification.json
@@ -23,5 +23,7 @@
   "prettier.notification.format-error.title": "Fehler beim Formatieren",
   "prettier.notification.format-error.body": "\n\nWeitere Informationen finden Sie in der Erweiterungskonsole.",
   "prettier.notification.unsupportedSyntax.body": "„Auswahl formatieren“ ist für diesen Dateityp nicht verfügbar. Unterstützte Syntax: JavaScript, TypeScript, GraphQL und Handlebars.\n\nDurch Klicken auf „Ausblenden“ wird der Befehl für nicht unterstützte Syntax deaktiviert.",
-  "prettier.notification.actions.dismiss": "Ausblenden"
+  "prettier.notification.actions.dismiss": "Ausblenden",
+  "prettier.notification.runtimeMissing.title": "",
+  "prettier.notification.runtimeMissing.body": ""
 }

--- a/translations/en.lproj/notification.json
+++ b/translations/en.lproj/notification.json
@@ -23,5 +23,7 @@
   "prettier.notification.format-error.title": "Error While Formatting",
   "prettier.notification.format-error.body": "\n\nSee the Extension Console for more info.",
   "prettier.notification.unsupportedSyntax.body": "“Format Selection” isn’t available for this file type. Supported syntaxes: JavaScript, TypeScript, GraphQL, and Handlebars.\n\nClicking “Dismiss” will disable the command for unsupported syntaxes.",
-  "prettier.notification.actions.dismiss": "Dismiss"
+  "prettier.notification.actions.dismiss": "Dismiss",
+  "prettier.notification.runtimeMissing.title": "Missing Runtime Tools",
+  "prettier.notification.runtimeMissing.body": "Please install Node.js (which includes npm) and ensure it’s on your PATH so Prettier⁺ can resolve correctly."
 }

--- a/translations/fr.lproj/notification.json
+++ b/translations/fr.lproj/notification.json
@@ -23,5 +23,7 @@
   "prettier.notification.format-error.title": "",
   "prettier.notification.format-error.body": "",
   "prettier.notification.unsupportedSyntax.body": "",
-  "prettier.notification.actions.dismiss": ""
+  "prettier.notification.actions.dismiss": "",
+  "prettier.notification.runtimeMissing.title": "",
+  "prettier.notification.runtimeMissing.body": ""
 }

--- a/translations/jp.lproj/notification.json
+++ b/translations/jp.lproj/notification.json
@@ -23,5 +23,7 @@
   "prettier.notification.format-error.title": "",
   "prettier.notification.format-error.body": "",
   "prettier.notification.unsupportedSyntax.body": "",
-  "prettier.notification.actions.dismiss": ""
+  "prettier.notification.actions.dismiss": "",
+  "prettier.notification.runtimeMissing.title": "",
+  "prettier.notification.runtimeMissing.body": ""
 }

--- a/translations/zh-Hans.lproj/notification.json
+++ b/translations/zh-Hans.lproj/notification.json
@@ -23,5 +23,7 @@
   "prettier.notification.format-error.title": "",
   "prettier.notification.format-error.body": "",
   "prettier.notification.unsupportedSyntax.body": "",
-  "prettier.notification.actions.dismiss": ""
+  "prettier.notification.actions.dismiss": "",
+  "prettier.notification.runtimeMissing.title": "",
+  "prettier.notification.runtimeMissing.body": ""
 }


### PR DESCRIPTION
Show a user-facing dialog when Node.js or npm cannot be detected, instructing  users to install Node.js (which includes npm) and ensure it’s on their PATH  so Prettier⁺ can resolve correctly.