### PR TITLE
fix: prevent Nova from stalling on save when Prettier isn’t ready

### DIFF
--- a/src/Scripts/formatter.js
+++ b/src/Scripts/formatter.js
@@ -9,18 +9,18 @@
  */
 
 const {
-  showError,
-  showActionableError,
-  log,
   getConfigWithWorkspaceOverride,
+  log,
+  showActionableError,
+  showError,
 } = require('./helpers.js')
 
 const pluginPaths = require('./prettier-plugins.js')
 
 const {
-  getDefaultConfig,
   getAstroConfig,
   getBladeConfig,
+  getDefaultConfig,
   getLiquidConfig,
   getNginxConfig,
   getNodeSqlParserConfig,

--- a/src/Scripts/module-resolver.js
+++ b/src/Scripts/module-resolver.js
@@ -142,7 +142,7 @@ module.exports = async function () {
       ),
       nova.localize(
         'prettier.notification.runtimeMissing.body',
-        'Please install Node.js (which includes npm) and ensure it’s on your PATH so Prettier⁺ can resolve correctly.',
+        'Please install Node.js (which includes npm) and ensure it’s on your PATH so Prettier⁺ can resolve correctly. Then restart Nova to apply the change.',
         'notification',
       ),
     )

--- a/translations/en.lproj/notification.json
+++ b/translations/en.lproj/notification.json
@@ -25,5 +25,5 @@
   "prettier.notification.unsupportedSyntax.body": "“Format Selection” isn’t available for this file type. Supported syntaxes: JavaScript, TypeScript, GraphQL, and Handlebars.\n\nClicking “Dismiss” will disable the command for unsupported syntaxes.",
   "prettier.notification.actions.dismiss": "Dismiss",
   "prettier.notification.runtimeMissing.title": "Missing Runtime Tools",
-  "prettier.notification.runtimeMissing.body": "Please install Node.js (which includes npm) and ensure it’s on your PATH so Prettier⁺ can resolve correctly."
+  "prettier.notification.runtimeMissing.body": "Please install Node.js (which includes npm) and ensure it’s on your PATH so Prettier⁺ can resolve correctly. Then restart Nova to apply the change."
 }


### PR DESCRIPTION
Wrap `formatter.isReady` (boolean or Promise) in `Promise.resolve` and defer setup of format-on-save until Prettier is confirmed ready, ensuring Nova no longer hangs on save.