### PR TITLE
chore: upgrade prettier plugins to use .js modules

### DIFF
--- a/prettier.novaextension/package-lock.json
+++ b/prettier.novaextension/package-lock.json
@@ -23,9 +23,9 @@
         "prettier-plugin-java": "^2.6.7",
         "prettier-plugin-nginx": "^1.0.3",
         "prettier-plugin-properties": "^0.3.0",
-        "prettier-plugin-sql": "^0.19.0",
+        "prettier-plugin-sql": "^0.19.1",
         "prettier-plugin-tailwindcss": "^0.6.11",
-        "prettier-plugin-toml": "^2.0.4"
+        "prettier-plugin-toml": "^2.0.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2468,12 +2468,12 @@
       }
     },
     "node_modules/prettier-plugin-sql": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-sql/-/prettier-plugin-sql-0.19.0.tgz",
-      "integrity": "sha512-xLeNS6AKMGI+nT3X9nvG/0G3C8XTykmJcVeBUIOXYVKylAC/z2QNJzw93yXqt/skmeRL7G7o23yTSvcza2n8Yw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-sql/-/prettier-plugin-sql-0.19.1.tgz",
+      "integrity": "sha512-Kvxs8uRBdwT64dg/+pjZN1dojLTfZjqtRss8jbUVLqGPXRDp0vJuPkR7otzyQz5no6jSkt6TGFvC80aOnXlpXw==",
       "license": "MIT",
       "dependencies": {
-        "jsox": "^1.2.121",
+        "jsox": "^1.2.123",
         "node-sql-parser": "^5.3.8",
         "sql-formatter": "^15.5.2",
         "tslib": "^2.8.1"
@@ -2567,9 +2567,9 @@
       }
     },
     "node_modules/prettier-plugin-toml": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-toml/-/prettier-plugin-toml-2.0.4.tgz",
-      "integrity": "sha512-uOTNPClqnE3T9XJ8hCqAJek70Jnk3/ZuAG/aXRTmrWbVe8lJyuZ60KV7OtgWqF+iGZOPVpkh+giHhX9GZYRHGA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-toml/-/prettier-plugin-toml-2.0.5.tgz",
+      "integrity": "sha512-WjXXKQyY4TdXWHU1v73UJxK/oDLSppf+b9KrSVl2kC4ZOr9CIVPKTQ/JxttgbYMaH8r3ihw7WYhMpI1EFa1obg==",
       "license": "MIT",
       "dependencies": {
         "@taplo/lib": "^0.5.0"

--- a/prettier.novaextension/package.json
+++ b/prettier.novaextension/package.json
@@ -26,9 +26,9 @@
     "prettier-plugin-java": "^2.6.7",
     "prettier-plugin-nginx": "^1.0.3",
     "prettier-plugin-properties": "^0.3.0",
-    "prettier-plugin-sql": "^0.19.0",
+    "prettier-plugin-sql": "^0.19.1",
     "prettier-plugin-tailwindcss": "^0.6.11",
-    "prettier-plugin-toml": "^2.0.4"
+    "prettier-plugin-toml": "^2.0.5"
   },
   "scripts": {
     "postinstall": "patch-package"

--- a/src/Scripts/prettier-plugins.js
+++ b/src/Scripts/prettier-plugins.js
@@ -78,7 +78,7 @@ module.exports = {
     'node_modules',
     'prettier-plugin-sql',
     'lib',
-    'index.cjs',
+    'index.js',
   ),
   tailwind: nova.path.join(
     nova.extension.path,
@@ -92,7 +92,7 @@ module.exports = {
     'node_modules',
     'prettier-plugin-toml',
     'lib',
-    'index.cjs',
+    'index.js',
   ),
   twig: nova.path.join(
     nova.extension.path,


### PR DESCRIPTION
-  Upgraded prettier-plugin-sql to version 0.19.1
-  Upgraded prettier-plugin-toml to version 2.0.5
-  Switched from .cjs to .js modules for compatibility with ES modules