### PR TITLE
Merge branch 'release/3.5.43' into develop

### DIFF
--- a/prettier.novaextension/patches/prettier-plugin-sql+0.19.1.patch
+++ b/prettier.novaextension/patches/prettier-plugin-sql+0.19.1.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/prettier-plugin-sql/lib/index.js b/node_modules/prettier-plugin-sql/lib/index.js
+index 0879ac1..b8ace14 100644
+--- a/node_modules/prettier-plugin-sql/lib/index.js
++++ b/node_modules/prettier-plugin-sql/lib/index.js
+@@ -6,6 +6,10 @@ const parser = new nodeSqlParser.Parser();
+ const SQL_FORMATTER = 'sql-formatter';
+ const NODE_SQL_PARSER = 'node-sql-parser';
+ const SQL_CST = 'sql-cst';
++
++// 32 MiB in bytes (characters)
++const MAX_SQL_FILE_SIZE = 32 * 1024 * 1024; // 33 554 432
++
+ const SqlPlugin = {
+     languages,
+     parsers: {
+@@ -16,8 +20,8 @@ const SqlPlugin = {
+                     : parser.astify(text, { type, database });
+             },
+             astFormat: 'sql',
+-            locStart: () => -1,
+-            locEnd: () => -1,
++            locStart: () => 0,
++            locEnd:   () => MAX_SQL_FILE_SIZE,
+         },
+     },
+     printers: {

--- a/prettier.novaextension/patches/prettier-plugin-toml+2.0.5.patch
+++ b/prettier.novaextension/patches/prettier-plugin-toml+2.0.5.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/prettier-plugin-toml/lib/index.js b/node_modules/prettier-plugin-toml/lib/index.js
+index e4ce0fc..577d466 100644
+--- a/node_modules/prettier-plugin-toml/lib/index.js
++++ b/node_modules/prettier-plugin-toml/lib/index.js
+@@ -2,6 +2,10 @@ import taplo from '@taplo/lib';
+ import { languages } from './languages.js';
+ import { prettierOptionsDefinitions } from './options.js';
+ const PLUGIN_NAME = 'toml';
++
++// 32 MiB in bytes (characters)
++const MAX_TOML_FILE_SIZE = 32 * 1024 * 1024; // 33 554 432
++
+ let taploIns;
+ async function format(code, options) {
+     if (!taploIns) {
+@@ -24,8 +28,8 @@ const TomlPlugin = {
+                 });
+             },
+             astFormat: PLUGIN_NAME,
+-            locStart: () => -1,
+-            locEnd: () => -1,
++            locStart: () => 0,
++            locEnd:   () => MAX_TOML_FILE_SIZE,
+         },
+     },
+     printers: {

--- a/src/Scripts/formatter.js
+++ b/src/Scripts/formatter.js
@@ -689,13 +689,15 @@ class Formatter {
       cursorOffset: newCursor,
     } = result
 
-    // UPSTREAM: `prettier-plugin-sql` & `prettier-plugin-toml` do not return a valid cursor
-    if (newCursor === 0 && (syntaxKey === 'sql' || syntaxKey === 'toml')) {
+    // newCursor may be a number or undefined/null.
+    if (newCursor == null) {
+      // Prettier really couldn’t compute a position
       this._cursorOffset = editor.selectedRange.start
       log.debug(
-        `Cursor position is 0. Adjusting cursor offset for ${syntaxKey} syntax to the current start range: ${editor.selectedRange.start}`,
+        `Prettier returned no cursor (null/undefined); falling back to editor position ${this._cursorOffset}`,
       )
     } else {
+      // A numeric cursor — trust it
       this._cursorOffset = newCursor
       log.debug('New Cursor Position:', newCursor)
     }


### PR DESCRIPTION
- Replace dummy `locStart: () => -1` / `locEnd: () => -1` with
  `locStart: () => 0` and `locEnd: () => MAX_*_FILE_SIZE`
- Ensure Prettier’s cursor logic always returns a defined position
  (never `undefined`)
- Add fallback in the editor integration: when Prettier reports `0`
  but the real cursor is elsewhere, use `editor.selectedRange.start`

Signed-off-by: Toni Förster <toni.foerster@icloud.com>